### PR TITLE
PxSizeMm and FocMm

### DIFF
--- a/CPP_Apero2Meshlab.cpp
+++ b/CPP_Apero2Meshlab.cpp
@@ -296,6 +296,7 @@ void Apero2MeshlabRast(string aFullPattern, string aOri, int aUnDist)
 
       ElCamera * aCam = Cam_Gen_From_File(aNameCam, "OrientationConique" , anICNM);
 
+
       ElMatrix<double> Rot(3,3,0.0);
       ElMatrix<double> RotX(3,3,0.0);
 
@@ -311,15 +312,22 @@ void Apero2MeshlabRast(string aFullPattern, string aOri, int aUnDist)
       Pt3d<double> Trans;
       Trans= -aCS->OrigineProf();
 
+      //Loading EXIF data, to get FocMm and Calculate PixelSizeMm
+      cMetaDataPhoto aMetaData = cMetaDataPhoto::CreateExiv2(aFullName);
+      double rap35MmThisFrame = aMetaData.Foc35()/aMetaData.FocMm();
+      double PxSize35Mm = euclid(Pt2di(24,36))/euclid(aMetaData.TifSzIm());
+      double PxSizeMm = PxSize35Mm / rap35MmThisFrame;
+
+
       //the focal
-      double focal = aCS->Focale() ;
+      double focal = aCS->Focale()*PxSizeMm;
 
       //and the other internal parameters
       Pt2d<double> distortions, pixelsize, principal_point;
       Pt2di viewport;
       viewport = aCS->Sz();
 
-      pixelsize.x = 1.0; pixelsize.y = 1.0; //we keep as 1 the pixelsize, always
+      pixelsize.x = PxSizeMm; pixelsize.y = PxSizeMm;
 
       if (aUnDist)
         {
@@ -354,10 +362,6 @@ void Apero2MeshlabRast(string aFullPattern, string aOri, int aUnDist)
           principal_point = cal_xml.PP();
 
           //BUT it seems that is causing problems when importing in meshlab.
-          // this probably depends upon the fact we are using the focal in pixel
-          // when meshlab would require it in mm.
-          // I dont know how to retrieve this measure from micmac, so for now we
-          // approximate to the center of the image.
 
           principal_point = viewport / 2.0;
 
@@ -417,7 +421,7 @@ int Apero2MeshlabRast_main(int argc,char ** argv)
 
   //Reading the arguments
   string aFullPattern,aOri;
-  int aUnDist = 0;
+  bool aUnDist = false;
 
   ElInitArgMain
       (

--- a/patchset.patch
+++ b/patchset.patch
@@ -5,7 +5,7 @@ diff --git a/include/general/arg_main.h b/include/general/arg_main.h
  int TestMTD_main(int argc,char ** argv);
  int TestCmds_main(int argc,char ** argv);
  int Apero2PMVS_main(int argc,char ** argv);
-+int Apero2Meshlab_main(int argc,char ** argv);
++int Apero2MeshlabRast_main(int argc,char ** argv);
  int Ori2XML_main(int argc,char ** argv);
  
  // uti_images
@@ -29,7 +29,7 @@ diff --git a/src/CBinaires/mm3d.cpp b/src/CBinaires/mm3d.cpp
         aRes.push_back(cMMCom("Digeo",Digeo_main," In devlopment- Will compute tie points "));
         aRes.push_back(cMMCom("AperoChImSecMM",AperoChImMM_main,"Select secondary images for MicMac",cArgLogCom(2)));
  	   aRes.push_back(cMMCom("Apero2PMVS",Apero2PMVS_main,"Convert Orientation from Apero-Micmac workflow to PMVS format"));
-+       aRes.push_back(cMMCom("Apero2Meshlab",Apero2Meshlab_main,"Convert Orientation from Apero-Micmac workflow to a meshlab-compatible format"));
++       aRes.push_back(cMMCom("Apero2Meshlab",Apero2MeshlabRast_main,"Convert Orientation from Apero-Micmac workflow to a meshlab-compatible format"));
         aRes.push_back(cMMCom("Bascule",Bascule_main," Generate orientations coherent with some physical information on the scene",cArgLogCom(2)));
         aRes.push_back(cMMCom("BatchFDC",BatchFDC_main," Tool for batching a set of commands"));
         aRes.push_back(cMMCom("Campari",Campari_main," Interface to Apero, for compensation of heterogenous measures",cArgLogCom(2)));


### PR DESCRIPTION
This patch intends to push real Px Size (in mm) and Focal length (in mm) in the mlp (from EXIF data).
...but it doesn't seem to solve the "random" misalignement between the mesh and the pictures.

This PR also contains a small fix in command line conventions.
